### PR TITLE
Gep 3388 revisions

### DIFF
--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -184,13 +184,6 @@ type BackendTrafficPolicySpec struct {
 // CommonRetryPolicy defines the configuration for when to retry a request.
 //
 type CommonRetryPolicy struct {
-    // TODO: Does it make sense to include this configuration in the policy or not?
-    //
-    // Support: Extended
-    //
-    // +optional
-    HTTP *HTTPRouteRetry `json:"http,omitempty"`
-
     // Support: Extended
     //
     // +optional
@@ -246,14 +239,6 @@ spec:
       name: istio
     - kind: Gateway
       name: foo-ingress
-  http:
-    codes:
-    - 500
-    - 502
-    - 503
-    - 504
-    attempts: 2
-    backoff: 100ms
   budgetPercent: 20
   budgetInterval: 10s
   minRetryRate:
@@ -299,14 +284,6 @@ spec:
     - kind: Gateway
       name: foo-ingress
   retry:
-    http:
-      codes:
-      - 500
-      - 502
-      - 503
-      - 504
-      attempts: 2
-      backoff: 100ms
     budgetPercent: 20
     budgetInterval: 10s
     minRetryRate:

--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -79,49 +79,9 @@ The implementation of a version of Linkerd's `ttl` parameter within Envoy might 
 
 ## API
 
-Two possible API designs are provided below, likely only one should be selected for implementation.
-
 ### Go
 
 ```golang
-type RetryPolicy struct {
-    // RetryPolicy defines the configuration for when to retry a request to a target backend.
-    // Implementations SHOULD retry on connection errors (disconnect, reset, timeout,
-    // TCP failure) if a retry stanza is configured.
-    //
-    // Support: Extended
-    //
-    // +optional
-    // <gateway:experimental>
-    //
-    // Note: there is no Override or Default policy configuration.
-
-    metav1.TypeMeta   `json:",inline"`
-    metav1.ObjectMeta `json:"metadata,omitempty"`
-
-    // Spec defines the desired state of BackendLBPolicy.
-    Spec RetryPolicySpec `json:"spec"`
-
-    // Status defines the current state of BackendLBPolicy.
-    Status PolicyStatus `json:"status,omitempty"`
-}
-
-type RetryPolicySpec struct {
-  // TargetRef identifies an API object to apply policy to.
-  // Currently, Backends (i.e. Service, ServiceImport, or any
-  // implementation-specific backendRef) are the only valid API
-  // target references.
-  // +listType=map
-  // +listMapKey=group
-  // +listMapKey=kind
-  // +listMapKey=name
-  // +kubebuilder:validation:MinItems=1
-  // +kubebuilder:validation:MaxItems=16
-  TargetRefs []LocalPolicyTargetReference `json:"targetRefs"`
-
-  CommonRetryPolicy `json:",inline"`
-}
-
 type BackendTrafficPolicy struct {
     // BackendTrafficPolicy defines the configuration for how traffic to a target backend should be handled.
     //
@@ -216,44 +176,6 @@ type RequestRate struct {
 type Duration string
 
 ### YAML
-
-```yaml
-apiVersion: gateway.networking.x-k8s.io/v1alpha1
-kind: RetryPolicy
-metadata:
-  name: retry-policy-example
-spec:
-  targetRefs:
-    - group: ""
-      kind: Service
-      name: foo
-  budgetPercent: 20
-  budgetInterval: 10s
-  minRetryRate:
-    count: 3
-    interval: 1s
-status:
-  ancestors:
-  - ancestorRef:
-      kind: Mesh
-      namespace: istio-system
-      name: istio
-    controllerName: "istio.io/mesh-controller"
-    conditions:
-    - type: "Accepted"
-      status: "True"
-      reason: "Accepted"
-  - ancestorRef:
-      kind: Gateway
-      namespace: foo-ns
-      name: foo-ingress
-    controllerName: "istio.io/mesh-controller"
-    conditions:
-    - type: "Accepted"
-      status: "False"
-      reason: "Invalid"
-      message: "RetryPolicy fields budgetPercentage, budgetInterval and minRetryRate are not supported for Istio ingress gateways."
-```
 
 ```yaml
 apiVersion: gateway.networking.x-k8s.io/v1alpha1

--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -119,9 +119,6 @@ type RetryPolicySpec struct {
   // +kubebuilder:validation:MaxItems=16
   TargetRefs []LocalPolicyTargetReference `json:"targetRefs"`
 
-  // TODO: This captures the basic idea, but should likely be a new type.
-  From []ReferenceGrantFrom `json:"from,omitempty"`
-
   CommonRetryPolicy `json:",inline"`
 }
 
@@ -157,9 +154,6 @@ type BackendTrafficPolicySpec struct {
   // +kubebuilder:validation:MinItems=1
   // +kubebuilder:validation:MaxItems=16
   TargetRefs []LocalPolicyTargetReference `json:"targetRefs"`
-
-  // TODO: This captures the basic idea, but should likely be a new type.
-  From []ReferenceGrantFrom `json:"from,omitempty"`
 
   // Retry defines the configuration for when to retry a request to a target backend.
   //
@@ -233,12 +227,6 @@ spec:
     - group: ""
       kind: Service
       name: foo
-  from:
-    - kind: Mesh
-      namespace: istio-system
-      name: istio
-    - kind: Gateway
-      name: foo-ingress
   budgetPercent: 20
   budgetInterval: 10s
   minRetryRate:
@@ -277,12 +265,6 @@ spec:
     - group: ""
       kind: Service
       name: foo
-  from:
-    - kind: Mesh
-      namespace: istio-system
-      name: istio
-    - kind: Gateway
-      name: foo-ingress
   retry:
     budgetPercent: 20
     budgetInterval: 10s


### PR DESCRIPTION
Removes declined considerations (HTTPRouteRetry clause in policy, standalone RetryPolicy instead of BackendTrafficPolicy) and deferred `From` scoping clause (to be reintroduced as a common policy attachment pattern proposal in a future memorandum GEP).